### PR TITLE
chore: place dependencies next to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"generate": "node generate",
 		"clean": "svgo --multipass --disable=removeViewBox --enable=addViewBox $(globby {svg,originals}/**/*.svg)"
 	},
+	"dependencies": {},
 	"devDependencies": {
 		"@svgr/core": "^6.5.1",
 		"alpha-sort": "^2.0.1",
@@ -57,6 +58,5 @@
 		"hooks": {
 			"pre-commit": "npm run clean && npm run generate"
 		}
-	},
-	"dependencies": {}
+	}
 }


### PR DESCRIPTION
For consistency with other repositories and to make it easy when scanning the package manifest to identify dependencies exhaustively.