### PR TITLE
DX-1941-fix-repo-url

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.18.1",
 	"description": "A set of icons for all the main cryptocurrencies and altcoins, in a range of styles and sizes",
 	"license": "CC0-1.0",
-	"repository": "atomiclabs/cryptocurrency-icons",
+	"repository": "BitGo/cryptocurrency-icons",
 	"homepage": "http://cryptoicons.co",
 	"files": [
 		"32",


### PR DESCRIPTION
Re-routed `repository` url to BitGo/cryptocurrency-icons to pass release check error:
`[7:14:24 PM] [semantic-release] › ✘ An error occurred while running semantic-release: ExecaError: Command failed with exit code 1: git fetch --tags 'https://x-access-token:[secure]@github.com/atomiclabs/cryptocurrency-icons.git'`

Ticket: DX-1941