### PR TITLE
fix: a CI fix, changing contents permission to write

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 


### PR DESCRIPTION
Addressing the `[1:49:19 PM] [semantic-release] › ✘  EGITNOPERMISSION Cannot push to the Git repository.
semantic-release cannot push the version tag to the branch master on the remote Git repository with URL https://x-access-token:[secure]@github.com/BitGo/cryptocurrency-icons.git.` release check error.

Changed semantic-release permissions for contents to `contents: write`.

Ticket: DX-1941