### PR TITLE
fix: set disable-semantic-release-git to true

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,4 +22,4 @@ jobs:
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}
     with:
-      disable-semantic-release-git: false
+      disable-semantic-release-git: true


### PR DESCRIPTION
Previously set `disable-semantic-release-git:` to `false`, to try and resolve the:
`[1:49:19 PM] [semantic-release] › ✘  EGITNOPERMISSION Cannot push to the Git repository.
semantic-release cannot push the version tag to the branch master on the remote Git repository with URL https://x-access-token:[secure]@github.com/BitGo/cryptocurrency-icons.git.` release check error. 

Setting it back to the original `disable-semantic-release-git: true`, to try and resolve the new:
`remote: - You're not authorized to push to this branch. Visit https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches for more information.` release check error.

Ticket: DX-1941